### PR TITLE
Fix Pages artifact path

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -33,6 +33,6 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: example/dist
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Upload the actual Slidev output directory produced for the example deck.

## Verification

- the build writes to example/dist
- the Pages failure was caused by uploading the nonexistent root dist directory